### PR TITLE
Implement NestJS-style modules and DI

### DIFF
--- a/framework/Attributes/Route.php
+++ b/framework/Attributes/Route.php
@@ -1,0 +1,13 @@
+<?php
+namespace AlphaPit\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class Route
+{
+    public function __construct(
+        public string $method,
+        public string $path
+    ) {}
+}

--- a/framework/DI/ServiceContainer.php
+++ b/framework/DI/ServiceContainer.php
@@ -1,0 +1,56 @@
+<?php
+namespace AlphaPit\DI;
+
+use ReflectionClass;
+use ReflectionNamedType;
+
+class ServiceContainer
+{
+    private array $entries = [];
+
+    public function set(string $id, mixed $concrete = null): void
+    {
+        $this->entries[$id] = $concrete ?? $id;
+    }
+
+    public function get(string $id): mixed
+    {
+        if (!array_key_exists($id, $this->entries)) {
+            return $this->build($id);
+        }
+
+        $concrete = $this->entries[$id];
+
+        if (is_callable($concrete)) {
+            $concrete = $concrete($this);
+            $this->entries[$id] = $concrete;
+        } elseif (is_string($concrete) && class_exists($concrete)) {
+            $concrete = $this->build($concrete);
+            $this->entries[$id] = $concrete;
+        }
+
+        return $concrete;
+    }
+
+    private function build(string $class): object
+    {
+        $ref = new ReflectionClass($class);
+        $ctor = $ref->getConstructor();
+        if (!$ctor) {
+            return new $class();
+        }
+
+        $params = [];
+        foreach ($ctor->getParameters() as $param) {
+            $type = $param->getType();
+            if ($type instanceof ReflectionNamedType && !$type->isBuiltin()) {
+                $params[] = $this->get($type->getName());
+            } elseif ($param->isDefaultValueAvailable()) {
+                $params[] = $param->getDefaultValue();
+            } else {
+                $params[] = null;
+            }
+        }
+        return $ref->newInstanceArgs($params);
+    }
+}

--- a/framework/Entity.php
+++ b/framework/Entity.php
@@ -1,0 +1,12 @@
+<?php
+namespace AlphaPit;
+
+use PDO;
+
+class Entity extends Model
+{
+    public function __construct(PDO $pdo)
+    {
+        parent::__construct($pdo, $this->table);
+    }
+}

--- a/framework/Module.php
+++ b/framework/Module.php
@@ -1,0 +1,29 @@
+<?php
+namespace AlphaPit;
+
+use AlphaPit\DI\ServiceContainer;
+
+class Module
+{
+    public array $controllers = [];
+    public array $providers = [];
+    public array $imports = [];
+
+    public function register(Router $router, ServiceContainer $container): void
+    {
+        foreach ($this->imports as $import) {
+            $module = $container->get($import);
+            if ($module instanceof Module) {
+                $module->register($router, $container);
+            }
+        }
+
+        foreach ($this->providers as $provider) {
+            $container->set($provider);
+        }
+
+        foreach ($this->controllers as $controller) {
+            $router->registerController($controller, $container);
+        }
+    }
+}

--- a/framework/Router.php
+++ b/framework/Router.php
@@ -1,6 +1,10 @@
 <?php
 namespace AlphaPit;
 
+use AlphaPit\Attributes\Route;
+use AlphaPit\DI\ServiceContainer;
+use AlphaPit\Module;
+
 class Router
 {
     private array $routes = [];
@@ -13,6 +17,25 @@ class Router
     public function post(string $path, callable $action): void
     {
         $this->routes['POST'][$path] = $action;
+    }
+
+    public function registerController(string $controller, ServiceContainer $container): void
+    {
+        $reflection = new \ReflectionClass($controller);
+        $instance = $container->get($controller);
+
+        foreach ($reflection->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+            foreach ($method->getAttributes(Route::class) as $attribute) {
+                /** @var Route $route */
+                $route = $attribute->newInstance();
+                $this->routes[$route->method][$route->path] = [$instance, $method->getName()];
+            }
+        }
+    }
+
+    public function registerModule(Module $module, ServiceContainer $container): void
+    {
+        $module->register($this, $container);
     }
 
     public function dispatch(string $method, string $uri): void

--- a/project/autoload.php
+++ b/project/autoload.php
@@ -1,0 +1,14 @@
+<?php
+spl_autoload_register(function ($class) {
+    $prefix = 'App\\';
+    $base_dir = __DIR__ . '/src/';
+    $len = strlen($prefix);
+    if (strncmp($prefix, $class, $len) !== 0) {
+        return;
+    }
+    $relative_class = substr($class, $len);
+    $file = $base_dir . str_replace('\\', '/', $relative_class) . '.php';
+    if (file_exists($file)) {
+        require $file;
+    }
+});

--- a/project/public/index.php
+++ b/project/public/index.php
@@ -1,11 +1,12 @@
 <?php
 require_once __DIR__ . '/../../framework/autoload.php';
+require_once __DIR__ . '/../autoload.php';
 define('VIEW_PATH', __DIR__ . '/../views');
 
 use AlphaPit\Router;
 use AlphaPit\Database;
-use AlphaPit\Model;
-use AlphaPit\Controller;
+use AlphaPit\DI\ServiceContainer;
+use App\AppModule;
 
 $config = [
     'host' => 'localhost',
@@ -15,23 +16,14 @@ $config = [
     'charset' => 'utf8mb4'
 ];
 
+
+$container = new ServiceContainer();
+$container->set(\PDO::class, function () use ($config) {
+    return Database::getInstance($config)->connection();
+});
+
 $router = new Router();
-
-$router->get('/', function () {
-    $controller = new class extends Controller {
-        public function index()
-        {
-            $this->view('home', ['title' => 'Welcome to AlphaPit']);
-        }
-    };
-    $controller->index();
-});
-
-$router->get('/users', function () use ($config) {
-    $db = Database::getInstance($config)->connection();
-    $model = new Model($db, 'users');
-    header('Content-Type: application/json');
-    echo json_encode($model->all());
-});
+$appModule = new AppModule();
+$router->registerModule($appModule, $container);
 
 $router->dispatch($_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI']);

--- a/project/src/AppModule.php
+++ b/project/src/AppModule.php
@@ -1,0 +1,11 @@
+<?php
+namespace App;
+
+use AlphaPit\Module;
+use App\User\UserModule;
+use App\Home\HomeModule;
+
+class AppModule extends Module
+{
+    public array $imports = [HomeModule::class, UserModule::class];
+}

--- a/project/src/Home/HomeController.php
+++ b/project/src/Home/HomeController.php
@@ -1,0 +1,14 @@
+<?php
+namespace App\Home;
+
+use AlphaPit\Controller;
+use AlphaPit\Attributes\Route;
+
+class HomeController extends Controller
+{
+    #[Route('GET', '/')]
+    public function index(): void
+    {
+        $this->view('home', ['title' => 'Welcome to AlphaPit']);
+    }
+}

--- a/project/src/Home/HomeModule.php
+++ b/project/src/Home/HomeModule.php
@@ -1,0 +1,9 @@
+<?php
+namespace App\Home;
+
+use AlphaPit\Module;
+
+class HomeModule extends Module
+{
+    public array $controllers = [HomeController::class];
+}

--- a/project/src/User/UserController.php
+++ b/project/src/User/UserController.php
@@ -1,0 +1,19 @@
+<?php
+namespace App\User;
+
+use AlphaPit\Controller;
+use AlphaPit\Attributes\Route;
+
+class UserController extends Controller
+{
+    public function __construct(private UserService $service)
+    {
+    }
+
+    #[Route('GET', '/users')]
+    public function index(): void
+    {
+        header('Content-Type: application/json');
+        echo json_encode($this->service->all());
+    }
+}

--- a/project/src/User/UserEntity.php
+++ b/project/src/User/UserEntity.php
@@ -1,0 +1,9 @@
+<?php
+namespace App\User;
+
+use AlphaPit\Entity;
+
+class UserEntity extends Entity
+{
+    protected string $table = 'users';
+}

--- a/project/src/User/UserModule.php
+++ b/project/src/User/UserModule.php
@@ -1,0 +1,10 @@
+<?php
+namespace App\User;
+
+use AlphaPit\Module;
+
+class UserModule extends Module
+{
+    public array $controllers = [UserController::class];
+    public array $providers = [UserService::class, UserEntity::class];
+}

--- a/project/src/User/UserService.php
+++ b/project/src/User/UserService.php
@@ -1,0 +1,14 @@
+<?php
+namespace App\User;
+
+class UserService
+{
+    public function __construct(private UserEntity $users)
+    {
+    }
+
+    public function all(): array
+    {
+        return $this->users->all();
+    }
+}


### PR DESCRIPTION
## Summary
- add `ServiceContainer` for basic dependency injection
- add `Module` class with controller and provider registration
- extend `Router` to register modules and attribute-based routes
- implement `Route` attribute for controller methods
- introduce base `Entity` class
- update example project to use modules and services

## Testing
- `php -l framework/DI/ServiceContainer.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ad594ea8832b96dd21d246d6c03e