### PR TITLE
Add environment config, dynamic routes, and model safeguards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DB_HOST=localhost
+DB_NAME=alpha
+DB_USER=root
+DB_PASSWORD=
+DB_CHARSET=utf8mb4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+/vendor/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ AlphaPit is a tiny PHP framework that provides a minimal router and lightweight 
 ## Getting started
 
 1. Clone the repository.
-2. Configure your database credentials in `project/public/index.php`.
+2. Copy `.env.example` to `.env` and configure your database credentials.
 3. Point your web server document root to the `project/public` directory.
 4. Open your browser and navigate to `/` to see the welcome page.
 
@@ -18,10 +18,11 @@ AlphaPit is a tiny PHP framework that provides a minimal router and lightweight 
 
 ## Example routes
 
-The `project/public/index.php` file registers two routes:
+The `project/public/index.php` file registers routes including parameterized ones:
 
 - `/` - renders the `project/views/home.php` template.
 - `/users` - returns all records from the `users` table in JSON format.
+- `/users/{id}` - fetches a single user by id.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,52 @@
+# AlphaPit Documentation
+
+This document explains how to run the sample project and how the framework pieces fit together.
+
+## Requirements
+- PHP 8.1 or higher with PDO extension
+- MySQL database server
+- Composer is not required; all classes use a simple autoloader
+
+## Quick start
+1. **Clone the repository**
+   ```bash
+   git clone https://example.com/AlphaPit.git
+   cd AlphaPit
+   ```
+2. **Configure the database**
+   Copy `.env.example` to `.env` and adjust the database credentials.
+3. **Launch the development server**
+   ```bash
+   php alpha.php serve
+   ```
+   This starts PHP's built-in server at `http://localhost:8000` serving the `project/public` directory.
+4. **Open the app**
+   Visit `http://localhost:8000` in your browser. The `/users` endpoint returns JSON data from the database.
+
+## Directory structure
+```
+framework/   # Core framework classes
+project/     # Example application using the framework
+  public/    # Entry point for web requests
+  src/       # Application modules, controllers, services and entities
+  views/     # PHP templates used by controllers
+alpha.php    # CLI tool for running the server and generating code
+```
+
+## How it works
+1. `project/public/index.php` bootstraps the framework. It sets up the service container, registers modules and hands control to the router.
+2. Modules extend `AlphaPit\Module` and can import other modules. Controllers inside a module use PHP 8 attributes `#[Route]` to define routes.
+3. The `Router` matches incoming requests, instantiates the controller and executes the action. Route parameters such as `/users/{id}` are supported and are passed to the controller method.
+4. Entities extend `AlphaPit\Entity` and use PDO for database access. Services encapsulate business logic and are automatically injected into controllers.
+
+## CLI usage
+The `alpha.php` script provides helper commands:
+- `php alpha.php serve [host:port]` – run the development server.
+- `php alpha.php g module <Name>` – generate a module skeleton.
+- `php alpha.php g controller <Module> <Name>` – generate a controller inside a module.
+- `php alpha.php g service <Module> <Name>` – generate a service class.
+- `php alpha.php g entity <Module> <Name>` – generate an entity class linked to a database table.
+
+## Next steps
+- Add more routes and templates inside `project` to build your application.
+- Extend the framework with middleware, parameterized routes or different database backends as needed.

--- a/framework/Database.php
+++ b/framework/Database.php
@@ -2,17 +2,27 @@
 namespace AlphaPit;
 
 use PDO;
+use PDOException;
 
 class Database
 {
     private static ?Database $instance = null;
-    private PDO $pdo;
+    private ?PDO $pdo = null;
 
     private function __construct(array $config)
     {
-        $dsn = "mysql:host={$config['host']};dbname={$config['dbname']};charset={$config['charset']}";
-        $this->pdo = new PDO($dsn, $config['user'], $config['password']);
-        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->connect($config);
+    }
+
+    private function connect(array $config): void
+    {
+        $dsn = sprintf('mysql:host=%s;dbname=%s;charset=%s', $config['host'], $config['dbname'], $config['charset']);
+        try {
+            $this->pdo = new PDO($dsn, $config['user'], $config['password']);
+            $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        } catch (PDOException $e) {
+            throw new \RuntimeException('Database connection failed: ' . $e->getMessage(), 0, $e);
+        }
     }
 
     public static function getInstance(array $config): Database
@@ -23,8 +33,28 @@ class Database
         return self::$instance;
     }
 
+    public static function reset(): void
+    {
+        self::$instance?->disconnect();
+        self::$instance = null;
+    }
+
+    public function reconnect(array $config): void
+    {
+        $this->disconnect();
+        $this->connect($config);
+    }
+
     public function connection(): PDO
     {
+        if ($this->pdo === null) {
+            throw new \RuntimeException('No active database connection');
+        }
         return $this->pdo;
+    }
+
+    public function disconnect(): void
+    {
+        $this->pdo = null;
     }
 }

--- a/framework/Env.php
+++ b/framework/Env.php
@@ -1,0 +1,22 @@
+<?php
+namespace AlphaPit;
+
+class Env
+{
+    public static function load(string $file): void
+    {
+        if (!is_readable($file)) {
+            return;
+        }
+        $lines = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        foreach ($lines as $line) {
+            if (str_starts_with(trim($line), '#')) {
+                continue;
+            }
+            [$name, $value] = array_map('trim', explode('=', $line, 2));
+            putenv("$name=$value");
+            $_ENV[$name] = $value;
+            $_SERVER[$name] = $value;
+        }
+    }
+}

--- a/framework/Model.php
+++ b/framework/Model.php
@@ -7,11 +7,20 @@ class Model
 {
     protected string $table;
     protected PDO $pdo;
+    protected array $fillable = [];
 
     public function __construct(PDO $pdo, string $table)
     {
         $this->pdo = $pdo;
         $this->table = $table;
+    }
+
+    protected function filterData(array $data): array
+    {
+        if ($this->fillable) {
+            $data = array_intersect_key($data, array_flip($this->fillable));
+        }
+        return $data;
     }
 
     public function find(int $id): ?array
@@ -30,7 +39,11 @@ class Model
 
     public function create(array $data): int
     {
-        $columns = implode(',', array_keys($data));
+        $data = $this->filterData($data);
+        if (!$data) {
+            throw new \InvalidArgumentException('No data provided for insert');
+        }
+        $columns = implode(',', array_map(fn($c) => "`$c`", array_keys($data)));
         $placeholders = implode(',', array_fill(0, count($data), '?'));
         $stmt = $this->pdo->prepare("INSERT INTO {$this->table} ({$columns}) VALUES ({$placeholders})");
         $stmt->execute(array_values($data));
@@ -39,7 +52,11 @@ class Model
 
     public function update(int $id, array $data): bool
     {
-        $set = implode(',', array_map(fn($c) => "$c = ?", array_keys($data)));
+        $data = $this->filterData($data);
+        if (!$data) {
+            throw new \InvalidArgumentException('No data provided for update');
+        }
+        $set = implode(',', array_map(fn($c) => "`$c` = ?", array_keys($data)));
         $values = array_values($data);
         $values[] = $id;
         $stmt = $this->pdo->prepare("UPDATE {$this->table} SET {$set} WHERE id = ?");

--- a/framework/Router.php
+++ b/framework/Router.php
@@ -11,12 +11,19 @@ class Router
 
     public function get(string $path, callable $action): void
     {
-        $this->routes['GET'][$path] = $action;
+        $this->addRoute('GET', $path, $action);
     }
 
     public function post(string $path, callable $action): void
     {
-        $this->routes['POST'][$path] = $action;
+        $this->addRoute('POST', $path, $action);
+    }
+
+    private function addRoute(string $method, string $path, callable $action): void
+    {
+        $pattern = preg_replace('#\{([^}]+)\}#', '(?P<$1>[^/]+)', $path);
+        $pattern = '#^' . $pattern . '$#';
+        $this->routes[$method][] = ['pattern' => $pattern, 'action' => $action];
     }
 
     public function registerController(string $controller, ServiceContainer $container): void
@@ -28,7 +35,7 @@ class Router
             foreach ($method->getAttributes(Route::class) as $attribute) {
                 /** @var Route $route */
                 $route = $attribute->newInstance();
-                $this->routes[$route->method][$route->path] = [$instance, $method->getName()];
+                $this->addRoute($route->method, $route->path, [$instance, $method->getName()]);
             }
         }
     }
@@ -41,14 +48,22 @@ class Router
     public function dispatch(string $method, string $uri): void
     {
         $uri = parse_url($uri, PHP_URL_PATH);
-        $action = $this->routes[$method][$uri] ?? null;
-
-        if (!$action) {
-            http_response_code(404);
-            echo 'Not Found';
-            return;
+        $routes = $this->routes[$method] ?? [];
+        foreach ($routes as $route) {
+            if (preg_match($route['pattern'], $uri, $matches)) {
+                $params = array_filter($matches, 'is_string', ARRAY_FILTER_USE_KEY);
+                try {
+                    echo call_user_func_array($route['action'], $params);
+                } catch (\Throwable $e) {
+                    error_log($e->getMessage());
+                    http_response_code(500);
+                    echo 'Internal Server Error';
+                }
+                return;
+            }
         }
 
-        echo call_user_func($action);
+        http_response_code(404);
+        echo 'Not Found';
     }
 }

--- a/project/public/index.php
+++ b/project/public/index.php
@@ -6,16 +6,18 @@ define('VIEW_PATH', __DIR__ . '/../views');
 use AlphaPit\Router;
 use AlphaPit\Database;
 use AlphaPit\DI\ServiceContainer;
+use AlphaPit\Env;
 use App\AppModule;
 
-$config = [
-    'host' => 'localhost',
-    'dbname' => 'alpha',
-    'user' => 'root',
-    'password' => '',
-    'charset' => 'utf8mb4'
-];
+Env::load(__DIR__ . '/../../.env');
 
+$config = [
+    'host' => getenv('DB_HOST') ?: 'localhost',
+    'dbname' => getenv('DB_NAME') ?: 'alpha',
+    'user' => getenv('DB_USER') ?: 'root',
+    'password' => getenv('DB_PASSWORD') ?: '',
+    'charset' => getenv('DB_CHARSET') ?: 'utf8mb4'
+];
 
 $container = new ServiceContainer();
 $container->set(\PDO::class, function () use ($config) {

--- a/project/src/User/UserController.php
+++ b/project/src/User/UserController.php
@@ -16,4 +16,17 @@ class UserController extends Controller
         header('Content-Type: application/json');
         echo json_encode($this->service->all());
     }
+
+    #[Route('GET', '/users/{id}')]
+    public function show(string $id): void
+    {
+        header('Content-Type: application/json');
+        $user = $this->service->find((int)$id);
+        if ($user) {
+            echo json_encode($user);
+        } else {
+            http_response_code(404);
+            echo json_encode(['error' => 'Not Found']);
+        }
+    }
 }

--- a/project/src/User/UserService.php
+++ b/project/src/User/UserService.php
@@ -11,4 +11,9 @@ class UserService
     {
         return $this->users->all();
     }
+
+    public function find(int $id): ?array
+    {
+        return $this->users->find($id);
+    }
 }


### PR DESCRIPTION
## Summary
- support parameterized routes and add endpoint for `/users/{id}`
- load database settings from `.env` and provide sample file
- improve database connection handling and filter model fields

## Testing
- `php -l framework/Router.php`
- `php -l framework/Env.php`
- `php -l framework/Database.php`
- `php -l framework/Model.php`
- `php -l project/public/index.php`
- `php -l project/src/User/UserService.php`
- `php -l project/src/User/UserController.php`


------
https://chatgpt.com/codex/tasks/task_e_6899a9592a8c832ba2d414e6f7d1f44c